### PR TITLE
Optional alpha channel + packing metadata into single uint256

### DIFF
--- a/contracts/ArtwrkMetadata.sol
+++ b/contracts/ArtwrkMetadata.sol
@@ -22,12 +22,12 @@ contract ArtwrkMetadata is Ownable {
 
         // Name
         string memory name = bytes32ToString(bytes32(murAllNFT.getName(_tokenId)));
-        metadata = strConcat("{\n  \"name\": \"", name);
-        metadata = strConcat(metadata, "\",\n");
+        metadata = strConcat('{\n  "name": "', name);
+        metadata = strConcat(metadata, '",\n');
 
         // Description: Artist
         string memory artist = toAsciiString(murAllNFT.getArtist(_tokenId));
-        metadata = strConcat(metadata, "  \"description\": \"By Artist ");
+        metadata = strConcat(metadata, '  "description": "By Artist ');
         metadata = strConcat(metadata, artist);
 
         // Description: Number
@@ -38,7 +38,14 @@ contract ArtwrkMetadata is Ownable {
         metadata = strConcat(metadata, " from Series ");
         metadata = strConcat(metadata, uintToStr(murAllNFT.getSeriesId(_tokenId)));
 
-        metadata = strConcat(metadata, "\",\n");
+        if (murAllNFT.hasAlphaChannel(_tokenId)) {
+            // Description: Alpha Channel
+            metadata = strConcat(metadata, ", with alpha (RGB565 channel ");
+            metadata = strConcat(metadata, uintToStr(murAllNFT.getAlphaChannel(_tokenId)));
+            metadata = strConcat(metadata, ")");
+        }
+
+        metadata = strConcat(metadata, '",\n');
 
         // View URI
         // metadata = strConcat(metadata, '  "external_url": "');
@@ -51,35 +58,45 @@ contract ArtwrkMetadata is Ownable {
         // metadata = strConcat(metadata, '",\n');
 
         // Attributes (ala OpenSea)
-        metadata = strConcat(metadata, "  \"attributes\": [\n");
+        metadata = strConcat(metadata, '  "attributes": [\n');
 
         // Name
         metadata = strConcat(metadata, "    {\n");
-        metadata = strConcat(metadata, "      \"trait_type\": \"name\",\n");
-        metadata = strConcat(metadata, "      \"value\": \"");
+        metadata = strConcat(metadata, '      "trait_type": "name",\n');
+        metadata = strConcat(metadata, '      "value": "');
         metadata = strConcat(metadata, name);
-        metadata = strConcat(metadata, "\"\n    },\n");
+        metadata = strConcat(metadata, '"\n    },\n');
 
         // Artist
         metadata = strConcat(metadata, "    {\n");
-        metadata = strConcat(metadata, "      \"trait_type\": \"artist\",\n");
-        metadata = strConcat(metadata, "      \"value\": \"");
+        metadata = strConcat(metadata, '      "trait_type": "artist",\n');
+        metadata = strConcat(metadata, '      "value": "');
         metadata = strConcat(metadata, artist);
-        metadata = strConcat(metadata, "\"\n    },\n");
+        metadata = strConcat(metadata, '"\n    },\n');
+
+        if (murAllNFT.hasAlphaChannel(_tokenId)) {
+            // Alpha Channel
+            metadata = strConcat(metadata, "    {\n");
+            metadata = strConcat(metadata, '      "display_type": "number",\n');
+            metadata = strConcat(metadata, '      "trait_type": "Alpha channel (RGB565)",\n');
+            metadata = strConcat(metadata, '      "value": ');
+            metadata = strConcat(metadata, uintToStr(murAllNFT.getAlphaChannel(_tokenId)));
+            metadata = strConcat(metadata, "\n    },\n");
+        }
 
         // Number
         metadata = strConcat(metadata, "    {\n");
-        metadata = strConcat(metadata, "      \"display_type\": \"number\",\n");
-        metadata = strConcat(metadata, "      \"trait_type\": \"number\",\n");
-        metadata = strConcat(metadata, "      \"value\": ");
+        metadata = strConcat(metadata, '      "display_type": "number",\n');
+        metadata = strConcat(metadata, '      "trait_type": "number",\n');
+        metadata = strConcat(metadata, '      "value": ');
         metadata = strConcat(metadata, uintToStr(murAllNFT.getNumber(_tokenId)));
         metadata = strConcat(metadata, "\n    },\n");
 
         // Series Id
         metadata = strConcat(metadata, "    {\n");
-        metadata = strConcat(metadata, "      \"display_type\": \"number\",\n");
-        metadata = strConcat(metadata, "      \"trait_type\": \"Series Id\",\n");
-        metadata = strConcat(metadata, "      \"value\": ");
+        metadata = strConcat(metadata, '      "display_type": "number",\n');
+        metadata = strConcat(metadata, '      "trait_type": "Series Id",\n');
+        metadata = strConcat(metadata, '      "value": ');
         metadata = strConcat(metadata, uintToStr(murAllNFT.getSeriesId(_tokenId)));
         metadata = strConcat(metadata, "\n    }\n");
 

--- a/contracts/MurAll.sol
+++ b/contracts/MurAll.sol
@@ -35,24 +35,25 @@ contract MurAll is ReentrancyGuard {
 
     //Declare an Event for when canvas is written to
     event Painted(
-        address indexed sender,
+        address indexed artist,
         uint256 indexed tokenId,
         uint256[] pixelData,
         uint256[] pixelGroups,
-        uint256[] pixelGroupIndexes
+        uint256[] pixelGroupIndexes,
+        uint256[2] metadata
     );
 
     /**
      * @param individualPixels     - individual RGB pixels (2 bytes) twinned with their respective positions (3 bytes) - 6 pixels per uint256
      * @param pixelGroups          - RGB pixels in groups of 16 (1 pixel every 2 bytes, RGB565 format)
      * @param pixelGroupIndexes    - Group indexes matching the groups (1 index for every 3 bytes, 10 indexes per 32 byte entry)
-     * @param metadata             - an array of 3 metadata items in order: name (string converted to uint256), number, seriesId
+     * @param metadata             - an array of 2 metadata items in order: name (32 byte string converted to uint256), other metadata (formatted byte array consiting of number, seriesId, alpha channel and alpha channel flag)
      */
     function setPixels(
         uint256[] memory individualPixels,
         uint256[] memory pixelGroups,
         uint256[] memory pixelGroupIndexes,
-        uint256[3] memory metadata
+        uint256[2] memory metadata
     ) public nonReentrant {
         uint256 pixelCount = 0;
 
@@ -116,7 +117,7 @@ contract MurAll is ReentrancyGuard {
             totalArtists++;
         }
 
-        emit Painted(msg.sender, tokenId, individualPixels, pixelGroups, pixelGroupIndexes);
+        emit Painted(msg.sender, tokenId, individualPixels, pixelGroups, pixelGroupIndexes, metadata);
     }
 
     function decodeAndCheckIndividualPixelIndexes(uint256 x)

--- a/test/ArtwrkMetadata.test.js
+++ b/test/ArtwrkMetadata.test.js
@@ -50,13 +50,31 @@ contract('ArtwrkMetadata', ([owner, user]) => {
     });
 
     describe('get metadata', async () => {
-        it('returns correct metadata', async () => {
-            const metadata = Array(3);
+        it('returns correct metadata with alpha channel', async () => {
+            const metadata = Array(2);
             metadata[0] = '0x68656c6c6f20776f726c64210000000000000000000000000000000000000000';
-            metadata[1] = '0x00000000000000000000000000000000000000000000000000000000000004D2';
-            metadata[2] = '0x000000000000000000000000000000000000000000000000000000000000162E';
+            metadata[1] = '0x0004D200162E0000000000000000000000000000000000000000000000010E11';
+
             const expectedMetadata =
-                '{\n  "name": "hello world!",\n  "description": "By Artist d0214cc91e1e611843ebc9afc0ed11c5daa48906, Number 1234 from Series 5678",\n  "attributes": [\n    {\n      "trait_type": "name",\n      "value": "hello world!"\n    },\n    {\n      "trait_type": "artist",\n      "value": "d0214cc91e1e611843ebc9afc0ed11c5daa48906"\n    },\n    {\n      "display_type": "number",\n      "trait_type": "number",\n      "value": 1234\n    },\n    {\n      "display_type": "number",\n      "trait_type": "Series Id",\n      "value": 5678\n    }\n  ]\n}';
+                '{\n  "name": "hello world!",\n  "description": "By Artist 108e053c1ddfdafffc019dd6042f602ba00513c4, Number 1234 from Series 5678, with alpha (RGB565 channel 4321)",\n  "attributes": [\n    {\n      "trait_type": "name",\n      "value": "hello world!"\n    },\n    {\n      "trait_type": "artist",\n      "value": "108e053c1ddfdafffc019dd6042f602ba00513c4"\n    },\n    {\n      "display_type": "number",\n      "trait_type": "Alpha channel (RGB565)",\n      "value": 4321\n    },\n    {\n      "display_type": "number",\n      "trait_type": "number",\n      "value": 1234\n    },\n    {\n      "display_type": "number",\n      "trait_type": "Series Id",\n      "value": 5678\n    }\n  ]\n}';
+            const tokenId = 0;
+
+            await mintTestToken(user, metadata);
+
+            const metadataRaw = await this.contract.getArtwrkMetadata(tokenId, {
+                from: user,
+            });
+
+            assert.equal(metadataRaw, expectedMetadata);
+        });
+
+        it('returns correct metadata without alpha channel', async () => {
+            const metadata = Array(2);
+            metadata[0] = '0x68656c6c6f20776f726c64210000000000000000000000000000000000000000';
+            metadata[1] = '0x0004D200162E0000000000000000000000000000000000000000000000000000';
+
+            const expectedMetadata =
+                '{\n  "name": "hello world!",\n  "description": "By Artist 108e053c1ddfdafffc019dd6042f602ba00513c4, Number 1234 from Series 5678",\n  "attributes": [\n    {\n      "trait_type": "name",\n      "value": "hello world!"\n    },\n    {\n      "trait_type": "artist",\n      "value": "108e053c1ddfdafffc019dd6042f602ba00513c4"\n    },\n    {\n      "display_type": "number",\n      "trait_type": "number",\n      "value": 1234\n    },\n    {\n      "display_type": "number",\n      "trait_type": "Series Id",\n      "value": 5678\n    }\n  ]\n}';
             const tokenId = 0;
 
             await mintTestToken(user, metadata);

--- a/test/MurAllMartketplace.test.js
+++ b/test/MurAllMartketplace.test.js
@@ -24,10 +24,9 @@ contract('MurAllMarketplace', ([owner, user]) => {
         pixelGroups[0] = pixelGroupsValue;
         const pixelGroupIndexes = Array(1);
         pixelGroupIndexes[0] = pixelGroupIndexesValue;
-        const metadata = Array(3);
+        const metadata = Array(2);
         metadata[0] = 1234;
         metadata[1] = 5678;
-        metadata[2] = 4321;
 
         await this.murAllNFT.mint(fromAddress, individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
             from: owner,

--- a/test/MurAllNFT.test.js
+++ b/test/MurAllNFT.test.js
@@ -35,10 +35,9 @@ contract('MurAllNFT', (accounts) => {
             pixelGroups[0] = pixelGroupsValue;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             await expectRevert(
                 contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
@@ -60,10 +59,9 @@ contract('MurAllNFT', (accounts) => {
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
             const firstTokenId = 0;
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
                 from: accounts[0],
@@ -88,10 +86,9 @@ contract('MurAllNFT', (accounts) => {
             pixelGroups[0] = pixelGroupsValue;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
                 from: accounts[0],
@@ -120,10 +117,9 @@ contract('MurAllNFT', (accounts) => {
             pixelGroups[0] = pixelGroupsValue;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
                 from: accounts[0],
@@ -145,10 +141,9 @@ contract('MurAllNFT', (accounts) => {
             pixelGroups[0] = pixelGroupsValue;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
                 from: accounts[0],
@@ -169,6 +164,69 @@ contract('MurAllNFT', (accounts) => {
         });
     });
 
+    describe('Get full NFT data', async () => {
+        it('reverts if artwork of minted token is not filled in NFT', async () => {
+            // Given minted token
+            const individualPixelsValue = '0xAABB000064AABB0000C8DDEE00012CFFEE000190CCBB0001F4AAFF0000020000';
+            const pixelGroupsValue = '0xAABBCCDDEEFFABCDEFAAAAAABBBBBBCCCCCCDDDDDDEEEEEEFFFFFF1122331234';
+            const pixelGroupIndexesValue = '0x00000A00001400001E00002800003200003C00004600005000005A0000640000';
+
+            const individualPixels = Array(1);
+            individualPixels[0] = individualPixelsValue;
+            const pixelGroups = Array(1);
+            pixelGroups[0] = pixelGroupsValue;
+            const pixelGroupIndexes = Array(1);
+            pixelGroupIndexes[0] = pixelGroupIndexesValue;
+            const metadata = Array(2);
+            metadata[0] = 1234;
+            metadata[1] = 5678;
+
+            await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
+                from: accounts[0],
+            });
+
+            const tokenId = 0;
+
+            await expectRevert(contract.getFullDataForId(tokenId), 'Artwork is unfinished');
+        });
+
+        it('returns correct data when NFT is filled', async () => {
+            const individualPixelsValue = '0xaabb000064aabb0000c8ddee00012cffee000190ccbb0001f4aaff0000020000';
+            const pixelGroupsValue = '0xaabbccddeeffabcdefaaaaaabbbbbbccccccddddddeeeeeeffffff1122331234';
+            const pixelGroupIndexesValue = '0x00000a00001400001e00002800003200003c00004600005000005a0000640000';
+
+            const individualPixels = Array(1);
+            individualPixels[0] = individualPixelsValue;
+            const pixelGroups = Array(1);
+            pixelGroups[0] = pixelGroupsValue;
+            const pixelGroupIndexes = Array(1);
+            pixelGroupIndexes[0] = pixelGroupIndexesValue;
+            const metadata = Array(2);
+            metadata[0] = 1234;
+            metadata[1] = 5678;
+
+            await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
+                from: accounts[0],
+            });
+
+            const tokenId = 0;
+            const receipt = await contract.fillData(tokenId, individualPixels, pixelGroups, pixelGroupIndexes, {
+                from: accounts[1],
+            });
+
+            const data = await contract.getFullDataForId(tokenId);
+            assert.equal(data.individualPixels.length, 1);
+            assert.equal(data.artist, accounts[1]);
+            assert.equal(web3.utils.padLeft(web3.utils.toHex(data.individualPixels[0]), 64), individualPixelsValue);
+            assert.equal(data.pixelGroups.length, 1);
+            assert.equal(web3.utils.padLeft(web3.utils.toHex(data.pixelGroups[0]), 64), pixelGroupsValue);
+            assert.equal(data.pixelGroupIndexes.length, 1);
+            assert.equal(web3.utils.padLeft(web3.utils.toHex(data.pixelGroupIndexes[0]), 64), pixelGroupIndexesValue);
+            assert.isTrue(web3.utils.toBN(metadata[0]).eq(data.name));
+            assert.isTrue(web3.utils.toBN(metadata[1]).eq(data.metadata));
+        });
+    });
+
     describe('Fill NFT data', async () => {
         it('fails when individualPixels data not matching original data', async () => {
             const individualPixelsValue = '0xAABB000064AABB0000C8DDEE00012CFFEE000190CCBB0001F4AAFF0000020000';
@@ -184,10 +242,9 @@ contract('MurAllNFT', (accounts) => {
             pixelGroups[0] = pixelGroupsValue;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             const firstTokenId = 0;
 
@@ -217,10 +274,9 @@ contract('MurAllNFT', (accounts) => {
             wrongPixelGroups[0] = wrongPixelGroupsValue;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
                 from: accounts[0],
@@ -250,10 +306,9 @@ contract('MurAllNFT', (accounts) => {
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
             const wrongPixelGroupIndexes = Array(1);
             wrongPixelGroupIndexes[0] = wrongPixelGroupIndexesValue;
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
                 from: accounts[0],
@@ -280,10 +335,9 @@ contract('MurAllNFT', (accounts) => {
             pixelGroups[0] = pixelGroupsValue;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
                 from: accounts[0],
@@ -310,10 +364,9 @@ contract('MurAllNFT', (accounts) => {
             pixelGroups[0] = pixelGroupsValue;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
                 from: accounts[0],
@@ -348,17 +401,23 @@ contract('MurAllNFT', (accounts) => {
             pixelGroups[0] = pixelGroupsValue;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
-            const name = 1234;
-            const number = 5678;
-            const seriesId = 4321;
-            const metadata = Array(3);
-            metadata[0] = name;
-            metadata[1] = number;
-            metadata[2] = seriesId;
 
-            await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
-                from: accounts[0],
-            });
+            const name = 1234;
+            const otherInfo = 5678;
+
+            const metadata = Array(2);
+            metadata[0] = name;
+            metadata[1] = otherInfo;
+            expectedName = await contract.mint(
+                accounts[1],
+                individualPixels,
+                pixelGroups,
+                pixelGroupIndexes,
+                metadata,
+                {
+                    from: accounts[0],
+                }
+            );
 
             const tokenId = 0;
 
@@ -381,14 +440,13 @@ contract('MurAllNFT', (accounts) => {
             pixelGroups[0] = pixelGroupsValue;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
-            const name = 1234;
-            const number = 5678;
-            const seriesId = 4321;
-            const metadata = Array(3);
-            metadata[0] = name;
-            metadata[1] = number;
-            metadata[2] = seriesId;
+            const name = '0x68656c6c6f20776f726c64210000000000000000000000000000000000000000';
+            const otherInfo = '0x0004D200162E0000000000000000000000000000000000000000000000010E11';
 
+            const metadata = Array(2);
+            metadata[0] = name;
+            metadata[1] = otherInfo;
+            const expectedNumber = 1234;
             await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
                 from: accounts[0],
             });
@@ -399,7 +457,7 @@ contract('MurAllNFT', (accounts) => {
             const returnedNumber = await contract.getNumber(tokenId);
 
             // returns expected number
-            assert.equal(returnedNumber, number);
+            assert.equal(returnedNumber, expectedNumber);
         });
 
         it('get SeriesId returns correct series id for minted token', async () => {
@@ -414,14 +472,13 @@ contract('MurAllNFT', (accounts) => {
             pixelGroups[0] = pixelGroupsValue;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
-            const name = 1234;
-            const number = 5678;
-            const seriesId = 4321;
-            const metadata = Array(3);
-            metadata[0] = name;
-            metadata[1] = number;
-            metadata[2] = seriesId;
+            const name = '0x68656c6c6f20776f726c64210000000000000000000000000000000000000000';
+            const otherInfo = '0x0004D200162E0000000000000000000000000000000000000000000000010E11';
 
+            const metadata = Array(2);
+            metadata[0] = name;
+            metadata[1] = otherInfo;
+            const expectedSeriesId = 5678;
             await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
                 from: accounts[0],
             });
@@ -432,7 +489,134 @@ contract('MurAllNFT', (accounts) => {
             const returnedSeriesId = await contract.getSeriesId(tokenId);
 
             // returns expected series id
-            assert.equal(returnedSeriesId, seriesId);
+            assert.equal(returnedSeriesId, expectedSeriesId);
+        });
+
+        it('get alpha channel returns correct alpha channel for minted token when has alpha', async () => {
+            // Given minted token
+            const individualPixelsValue = '0xAABB000064AABB0000C8DDEE00012CFFEE000190CCBB0001F4AAFF0000020000';
+            const pixelGroupsValue = '0xAABBCCDDEEFFABCDEFAAAAAABBBBBBCCCCCCDDDDDDEEEEEEFFFFFF1122331234';
+            const pixelGroupIndexesValue = '0x00000A00001400001E00002800003200003C00004600005000005A0000640000';
+
+            const individualPixels = Array(1);
+            individualPixels[0] = individualPixelsValue;
+            const pixelGroups = Array(1);
+            pixelGroups[0] = pixelGroupsValue;
+            const pixelGroupIndexes = Array(1);
+            pixelGroupIndexes[0] = pixelGroupIndexesValue;
+            const name = '0x68656c6c6f20776f726c64210000000000000000000000000000000000000000';
+            const otherInfo = '0x0004D200162E0000000000000000000000000000000000000000000000010E11';
+
+            const metadata = Array(2);
+            metadata[0] = name;
+            metadata[1] = otherInfo;
+            const expectedAlpha = 4321;
+            await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
+                from: accounts[0],
+            });
+
+            const tokenId = 0;
+
+            // when getAlphaChannel
+            const returnedAlpha = await contract.getAlphaChannel(tokenId);
+
+            // returns expected alpha channel
+            assert.equal(returnedAlpha, expectedAlpha);
+        });
+
+        it('get alpha channel reverts when minted token has no alpha', async () => {
+            // Given minted token
+            const individualPixelsValue = '0xAABB000064AABB0000C8DDEE00012CFFEE000190CCBB0001F4AAFF0000020000';
+            const pixelGroupsValue = '0xAABBCCDDEEFFABCDEFAAAAAABBBBBBCCCCCCDDDDDDEEEEEEFFFFFF1122331234';
+            const pixelGroupIndexesValue = '0x00000A00001400001E00002800003200003C00004600005000005A0000640000';
+
+            const individualPixels = Array(1);
+            individualPixels[0] = individualPixelsValue;
+            const pixelGroups = Array(1);
+            pixelGroups[0] = pixelGroupsValue;
+            const pixelGroupIndexes = Array(1);
+            pixelGroupIndexes[0] = pixelGroupIndexesValue;
+            const name = '0x68656c6c6f20776f726c64210000000000000000000000000000000000000000';
+            const otherInfo = '0x0004D200162E0000000000000000000000000000000000000000000000010E10';
+
+            const metadata = Array(2);
+            metadata[0] = name;
+            metadata[1] = otherInfo;
+            const expectedAlpha = 4321;
+            await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
+                from: accounts[0],
+            });
+
+            const tokenId = 0;
+
+            // reverts when getAlphaChannel
+            await expectRevert(contract.getAlphaChannel(tokenId), 'Artwork has no alpha');
+        });
+
+        it('has alpha channel returns true if alpha channel exists for minted token', async () => {
+            // Given minted token
+            const individualPixelsValue = '0xAABB000064AABB0000C8DDEE00012CFFEE000190CCBB0001F4AAFF0000020000';
+            const pixelGroupsValue = '0xAABBCCDDEEFFABCDEFAAAAAABBBBBBCCCCCCDDDDDDEEEEEEFFFFFF1122331234';
+            const pixelGroupIndexesValue = '0x00000A00001400001E00002800003200003C00004600005000005A0000640000';
+
+            const individualPixels = Array(1);
+            individualPixels[0] = individualPixelsValue;
+            const pixelGroups = Array(1);
+            pixelGroups[0] = pixelGroupsValue;
+            const pixelGroupIndexes = Array(1);
+            pixelGroupIndexes[0] = pixelGroupIndexesValue;
+            const name = '0x68656c6c6f20776f726c64210000000000000000000000000000000000000000';
+            // last bit represents the alpha channel existing
+            const otherInfo = '0x0004D200162E0000000000000000000000000000000000000000000000010E11';
+
+            const metadata = Array(2);
+            metadata[0] = name;
+            metadata[1] = otherInfo;
+
+            await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
+                from: accounts[0],
+            });
+
+            const tokenId = 0;
+
+            // when getAlphaChannel
+            const hasAlpha = await contract.hasAlphaChannel(tokenId);
+
+            // returns true
+            assert.isTrue(hasAlpha);
+        });
+
+        it('has alpha channel returns false if alpha channel does not exist for minted token', async () => {
+            // Given minted token
+            const individualPixelsValue = '0xAABB000064AABB0000C8DDEE00012CFFEE000190CCBB0001F4AAFF0000020000';
+            const pixelGroupsValue = '0xAABBCCDDEEFFABCDEFAAAAAABBBBBBCCCCCCDDDDDDEEEEEEFFFFFF1122331234';
+            const pixelGroupIndexesValue = '0x00000A00001400001E00002800003200003C00004600005000005A0000640000';
+
+            const individualPixels = Array(1);
+            individualPixels[0] = individualPixelsValue;
+            const pixelGroups = Array(1);
+            pixelGroups[0] = pixelGroupsValue;
+            const pixelGroupIndexes = Array(1);
+            pixelGroupIndexes[0] = pixelGroupIndexesValue;
+            const name = '0x68656c6c6f20776f726c64210000000000000000000000000000000000000000';
+            // last bit represents the alpha channel existing
+            const otherInfo = '0x0004D200162E0000000000000000000000000000000000000000000000010E10';
+
+            const metadata = Array(2);
+            metadata[0] = name;
+            metadata[1] = otherInfo;
+
+            await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
+                from: accounts[0],
+            });
+
+            const tokenId = 0;
+
+            // when getAlphaChannel
+            const hasAlpha = await contract.hasAlphaChannel(tokenId);
+
+            // returns false
+            assert.isFalse(hasAlpha);
         });
 
         it('get artist returns correct artist address for minted token', async () => {
@@ -449,11 +633,10 @@ contract('MurAllNFT', (accounts) => {
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
             const name = 1234;
             const number = 5678;
-            const seriesId = 4321;
-            const metadata = Array(3);
+
+            const metadata = Array(2);
             metadata[0] = name;
             metadata[1] = number;
-            metadata[2] = seriesId;
 
             await contract.mint(accounts[1], individualPixels, pixelGroups, pixelGroupIndexes, metadata, {
                 from: accounts[0],

--- a/test/Murall.test.js
+++ b/test/Murall.test.js
@@ -59,10 +59,9 @@ contract('MurAll', ([owner, user]) => {
             individualPixels[0] = pixelOutOfRange;
             const pixelGroups = Array(0);
             const pixelGroupIndexes = Array(0);
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             await setAllowance(6);
 
@@ -82,10 +81,9 @@ contract('MurAll', ([owner, user]) => {
             pixelGroups[0] = pixel;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupOutOfRange;
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             await setAllowance(16);
 
@@ -95,12 +93,13 @@ contract('MurAll', ([owner, user]) => {
             );
         });
 
-        /* TODO this test fails even though the expected parameters are correct, needs investigation*/
         it('emits painted event with correct data', async () => {
             // given
-            const pixel = '0x0000cc83000007cc83000001cc83000002cc83000003cc83000004cc83000005';
-            const pixelGroup = '0x26a4d3a4217ad135efa1f04d7e4ef6a2f0a240be135e17a75fa2414eb2fad6ab';
-            const pixelGroupIndex = '0x000000000a00001400001e00002800003200003c00004600005000005a000064';
+            const pixel = web3.utils.toBN('0x0000cc83000007cc83000001cc83000002cc83000003cc83000004cc83000005');
+            const pixelGroup = web3.utils.toBN('0x26a4d3a4217ad135efa1f04d7e4ef6a2f0a240be135e17a75fa2414eb2fad6ab');
+            const pixelGroupIndex = web3.utils.toBN(
+                '0x000000000a00001400001e00002800003200003c00004600005000005a000064'
+            );
 
             const pixelData = Array(1);
             pixelData[0] = pixel;
@@ -108,23 +107,23 @@ contract('MurAll', ([owner, user]) => {
             pixelGroups[0] = pixelGroup;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndex;
-            const metadata = Array(3);
-            metadata[0] = 1234;
-            metadata[1] = 5678;
-            metadata[2] = 4321;
+            const metadata = Array(2);
+            metadata[0] = web3.utils.toBN(1234);
+            metadata[1] = web3.utils.toBN(5678);
 
             await setAllowance(22);
 
             const receipt = await this.contract.setPixels(pixelData, pixelGroups, pixelGroupIndexes, metadata, {
                 from: user,
             });
-            // TODO the array data seems to be failing the assert even though the data is equal, needs investigation
+            // TODO Openzeppelin test helpers currently can't assert arrays of BigNumber https://github.com/OpenZeppelin/openzeppelin-test-helpers/issues/1
             await expectEvent(receipt, 'Painted', {
-                sender: user,
+                artist: user,
                 tokenId: '0',
-                /*pixelData: pixelData,
-                pixelGroups: pixelGroups,
-                pixelGroupIndexes: pixelGroupIndexes,*/
+                // pixelData: pixelData,
+                // pixelGroups: pixelGroups,
+                // pixelGroupIndexes: pixelGroupIndexes,
+                // metadata: metadata,
             });
         });
 
@@ -140,19 +139,18 @@ contract('MurAll', ([owner, user]) => {
             pixelGroups[0] = pixelGroup;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndex;
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             await setAllowance(22);
 
-            assert.equal(await this.contract.isArtist(user), false);
+            assert.isFalse(await this.contract.isArtist(user));
             assert.equal(await this.contract.totalArtists(), 0);
 
             await this.contract.setPixels(pixelData, pixelGroups, pixelGroupIndexes, metadata, { from: user });
 
-            assert.equal(await this.contract.isArtist(user), true);
+            assert.isTrue(await this.contract.isArtist(user));
             assert.equal(await this.contract.totalArtists(), 1);
         });
 
@@ -168,24 +166,23 @@ contract('MurAll', ([owner, user]) => {
             pixelGroups[0] = pixelGroup;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndex;
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             await setAllowance(44);
 
-            assert.equal(await this.contract.isArtist(user), false);
+            assert.isFalse(await this.contract.isArtist(user));
             assert.equal(await this.contract.totalArtists(), 0);
 
             await this.contract.setPixels(pixelData, pixelGroups, pixelGroupIndexes, metadata, { from: user });
 
-            assert.equal(await this.contract.isArtist(user), true);
+            assert.isTrue(await this.contract.isArtist(user));
             assert.equal(await this.contract.totalArtists(), 1);
 
             await this.contract.setPixels(pixelData, pixelGroups, pixelGroupIndexes, metadata, { from: user });
 
-            assert.equal(await this.contract.isArtist(user), true);
+            assert.isTrue(await this.contract.isArtist(user));
             assert.equal(await this.contract.totalArtists(), 1);
         });
 
@@ -201,10 +198,9 @@ contract('MurAll', ([owner, user]) => {
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
             const firstTokenId = 0;
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             await setAllowance(22);
 
@@ -226,10 +222,9 @@ contract('MurAll', ([owner, user]) => {
             pixelGroups[0] = pixelGroupsValue;
             const pixelGroupIndexes = Array(1);
             pixelGroupIndexes[0] = pixelGroupIndexesValue;
-            const metadata = Array(3);
+            const metadata = Array(2);
             metadata[0] = 1234;
             metadata[1] = 5678;
-            metadata[2] = 4321;
 
             const startSupply = await this.paintToken.totalSupply();
             const pixelCount = 22;


### PR DESCRIPTION
- Added optional alpha channel to artwork, with custom colour
- all metadata apart from name is now squeezed into a single uint256, so number and seriesId are both uint24 (up to 16,777,215), alpha channel is 2 bytes, boolean to switch on alpha channel is 1 bit
- emitting metadata in Painted event
- added getter for all NFT data for id, returning artwork + metadata in 1 call