### PR TITLE
Added MurAll Roles ERC1155 NFT 

### DIFF
--- a/contracts/roles/ERC1155.sol
+++ b/contracts/roles/ERC1155.sol
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155MetadataURI.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import "@openzeppelin/contracts/GSN/Context.sol";
+import "@openzeppelin/contracts/introspection/ERC165.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+
+/**
+ *
+ * @dev Implementation of the basic standard multi-token.
+ * See https://eips.ethereum.org/EIPS/eip-1155
+ * Originally based on code by Enjin: https://github.com/enjin/erc-1155
+ *
+ * _Available since v3.1._
+ */
+abstract contract ERC1155 is Context, ERC165, IERC1155, IERC1155MetadataURI {
+    using SafeMath for uint256;
+    using Address for address;
+
+    // Mapping from token ID to account balances
+    mapping(uint256 => mapping(address => uint256)) private _balances;
+
+    // Mapping from account to operator approvals
+    mapping(address => mapping(address => bool)) private _operatorApprovals;
+
+    // Used as the URI for all token types by relying on ID substition, e.g. https://token-cdn-domain/{id}.json
+    string private _uri;
+
+    /*
+     *     bytes4(keccak256('balanceOf(address,uint256)')) == 0x00fdd58e
+     *     bytes4(keccak256('balanceOfBatch(address[],uint256[])')) == 0x4e1273f4
+     *     bytes4(keccak256('setApprovalForAll(address,bool)')) == 0xa22cb465
+     *     bytes4(keccak256('isApprovedForAll(address,address)')) == 0xe985e9c5
+     *     bytes4(keccak256('safeTransferFrom(address,address,uint256,uint256,bytes)')) == 0xf242432a
+     *     bytes4(keccak256('safeBatchTransferFrom(address,address,uint256[],uint256[],bytes)')) == 0x2eb2c2d6
+     *
+     *     => 0x00fdd58e ^ 0x4e1273f4 ^ 0xa22cb465 ^
+     *        0xe985e9c5 ^ 0xf242432a ^ 0x2eb2c2d6 == 0xd9b67a26
+     */
+    bytes4 private constant _INTERFACE_ID_ERC1155 = 0xd9b67a26;
+
+    /*
+     *     bytes4(keccak256('uri(uint256)')) == 0x0e89341c
+     */
+    bytes4 private constant _INTERFACE_ID_ERC1155_METADATA_URI = 0x0e89341c;
+
+    /**
+     * @dev See {_setURI}.
+     */
+    constructor(string memory uri) public {
+        _setURI(uri);
+
+        // register the supported interfaces to conform to ERC1155 via ERC165
+        _registerInterface(_INTERFACE_ID_ERC1155);
+
+        // register the supported interfaces to conform to ERC1155MetadataURI via ERC165
+        _registerInterface(_INTERFACE_ID_ERC1155_METADATA_URI);
+    }
+
+    /**
+     * @dev See {IERC1155-balanceOf}.
+     *
+     * Requirements:
+     *
+     * - `account` cannot be the zero address.
+     */
+    function balanceOf(address account, uint256 id) public override view returns (uint256) {
+        require(account != address(0), "ERC1155: balance query for the zero address");
+        return _balances[id][account];
+    }
+
+    /**
+     * @dev See {IERC1155-balanceOfBatch}.
+     *
+     * Requirements:
+     *
+     * - `accounts` and `ids` must have the same length.
+     */
+    function balanceOfBatch(address[] memory accounts, uint256[] memory ids)
+        public
+        override
+        view
+        returns (uint256[] memory)
+    {
+        require(accounts.length == ids.length, "ERC1155: accounts and ids length mismatch");
+
+        uint256[] memory batchBalances = new uint256[](accounts.length);
+
+        for (uint256 i = 0; i < accounts.length; ++i) {
+            require(accounts[i] != address(0), "ERC1155: batch balance query for the zero address");
+            batchBalances[i] = _balances[ids[i]][accounts[i]];
+        }
+
+        return batchBalances;
+    }
+
+    /**
+     * @dev See {IERC1155-setApprovalForAll}.
+     */
+    function setApprovalForAll(address operator, bool approved) public virtual override {
+        require(_msgSender() != operator, "ERC1155: setting approval status for self");
+
+        _operatorApprovals[_msgSender()][operator] = approved;
+        emit ApprovalForAll(_msgSender(), operator, approved);
+    }
+
+    /**
+     * @dev See {IERC1155-isApprovedForAll}.
+     */
+    function isApprovedForAll(address account, address operator) public override view returns (bool) {
+        return _operatorApprovals[account][operator];
+    }
+
+    /**
+     * @dev See {IERC1155-safeTransferFrom}.
+     */
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) public virtual override {
+        require(to != address(0), "ERC1155: transfer to the zero address");
+        require(
+            from == _msgSender() || isApprovedForAll(from, _msgSender()),
+            "ERC1155: caller is not owner nor approved"
+        );
+
+        address operator = _msgSender();
+
+        _beforeTokenTransfer(operator, from, to, _asSingletonArray(id), _asSingletonArray(amount), data);
+
+        _balances[id][from] = _balances[id][from].sub(amount, "ERC1155: insufficient balance for transfer");
+        _balances[id][to] = _balances[id][to].add(amount);
+
+        emit TransferSingle(operator, from, to, id, amount);
+
+        _doSafeTransferAcceptanceCheck(operator, from, to, id, amount, data);
+    }
+
+    /**
+     * @dev See {IERC1155-safeBatchTransferFrom}.
+     */
+    function safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory amounts,
+        bytes memory data
+    ) public virtual override {
+        require(ids.length == amounts.length, "ERC1155: ids and amounts length mismatch");
+        require(to != address(0), "ERC1155: transfer to the zero address");
+        require(
+            from == _msgSender() || isApprovedForAll(from, _msgSender()),
+            "ERC1155: transfer caller is not owner nor approved"
+        );
+
+        address operator = _msgSender();
+
+        _beforeTokenTransfer(operator, from, to, ids, amounts, data);
+
+        for (uint256 i = 0; i < ids.length; ++i) {
+            uint256 id = ids[i];
+            uint256 amount = amounts[i];
+
+            _balances[id][from] = _balances[id][from].sub(amount, "ERC1155: insufficient balance for transfer");
+            _balances[id][to] = _balances[id][to].add(amount);
+        }
+
+        emit TransferBatch(operator, from, to, ids, amounts);
+
+        _doSafeBatchTransferAcceptanceCheck(operator, from, to, ids, amounts, data);
+    }
+
+    /**
+     * @dev Sets a new URI for all token types, by relying on the token type ID
+     * substituion mechanism
+     * https://eips.ethereum.org/EIPS/eip-1155#metadata[defined in the EIP].
+     *
+     * By this mechanism, any occurence of the `\{id\}` substring in either the
+     * URI or any of the amounts in the JSON file at said URI will be replaced by
+     * clients with the token type ID.
+     *
+     * For example, the `https://token-cdn-domain/\{id\}.json` URI would be
+     * interpreted by clients as
+     * `https://token-cdn-domain/000000000000000000000000000000000000000000000000000000000004cce0.json`
+     * for token type ID 0x4cce0.
+     *
+     * See {uri}.
+     *
+     * Because these URIs cannot be meaningfully represented by the {URI} event,
+     * this function emits no events.
+     */
+    function _setURI(string memory newuri) internal virtual {
+        _uri = newuri;
+    }
+
+    /**
+     * @dev Creates `amount` tokens of token type `id`, and assigns them to `account`.
+     *
+     * Emits a {TransferSingle} event.
+     *
+     * Requirements:
+     *
+     * - `account` cannot be the zero address.
+     * - If `to` refers to a smart contract, it must implement {IERC1155Receiver-onERC1155Received} and return the
+     * acceptance magic value.
+     */
+    function _mint(
+        address account,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) internal virtual {
+        require(account != address(0), "ERC1155: mint to the zero address");
+
+        address operator = _msgSender();
+
+        _beforeTokenTransfer(operator, address(0), account, _asSingletonArray(id), _asSingletonArray(amount), data);
+
+        _balances[id][account] = _balances[id][account].add(amount);
+        emit TransferSingle(operator, address(0), account, id, amount);
+
+        _doSafeTransferAcceptanceCheck(operator, address(0), account, id, amount, data);
+    }
+
+    /**
+     * @dev xref:ROOT:erc1155.adoc#batch-operations[Batched] version of {_mint}.
+     *
+     * Requirements:
+     *
+     * - `ids` and `amounts` must have the same length.
+     * - If `to` refers to a smart contract, it must implement {IERC1155Receiver-onERC1155BatchReceived} and return the
+     * acceptance magic value.
+     */
+    function _mintBatch(
+        address to,
+        uint256[] memory ids,
+        uint256[] memory amounts,
+        bytes memory data
+    ) internal virtual {
+        require(to != address(0), "ERC1155: mint to the zero address");
+        require(ids.length == amounts.length, "ERC1155: ids and amounts length mismatch");
+
+        address operator = _msgSender();
+
+        _beforeTokenTransfer(operator, address(0), to, ids, amounts, data);
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            _balances[ids[i]][to] = amounts[i].add(_balances[ids[i]][to]);
+        }
+
+        emit TransferBatch(operator, address(0), to, ids, amounts);
+
+        _doSafeBatchTransferAcceptanceCheck(operator, address(0), to, ids, amounts, data);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens of token type `id` from `account`
+     *
+     * Requirements:
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens of token type `id`.
+     */
+    function _burn(
+        address account,
+        uint256 id,
+        uint256 amount
+    ) internal virtual {
+        require(account != address(0), "ERC1155: burn from the zero address");
+
+        address operator = _msgSender();
+
+        _beforeTokenTransfer(operator, account, address(0), _asSingletonArray(id), _asSingletonArray(amount), "");
+
+        _balances[id][account] = _balances[id][account].sub(amount, "ERC1155: burn amount exceeds balance");
+
+        emit TransferSingle(operator, account, address(0), id, amount);
+    }
+
+    /**
+     * @dev xref:ROOT:erc1155.adoc#batch-operations[Batched] version of {_burn}.
+     *
+     * Requirements:
+     *
+     * - `ids` and `amounts` must have the same length.
+     */
+    function _burnBatch(
+        address account,
+        uint256[] memory ids,
+        uint256[] memory amounts
+    ) internal virtual {
+        require(account != address(0), "ERC1155: burn from the zero address");
+        require(ids.length == amounts.length, "ERC1155: ids and amounts length mismatch");
+
+        address operator = _msgSender();
+
+        _beforeTokenTransfer(operator, account, address(0), ids, amounts, "");
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            _balances[ids[i]][account] = _balances[ids[i]][account].sub(
+                amounts[i],
+                "ERC1155: burn amount exceeds balance"
+            );
+        }
+
+        emit TransferBatch(operator, account, address(0), ids, amounts);
+    }
+
+    /**
+     * @dev Hook that is called before any token transfer. This includes minting
+     * and burning, as well as batched variants.
+     *
+     * The same hook is called on both single and batched variants. For single
+     * transfers, the length of the `id` and `amount` arrays will be 1.
+     *
+     * Calling conditions (for each `id` and `amount` pair):
+     *
+     * - When `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * of token type `id` will be  transferred to `to`.
+     * - When `from` is zero, `amount` tokens of token type `id` will be minted
+     * for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens of token type `id`
+     * will be burned.
+     * - `from` and `to` are never both zero.
+     * - `ids` and `amounts` have the same, non-zero length.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(
+        address operator,
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory amounts,
+        bytes memory data
+    ) internal virtual {}
+
+    function _doSafeTransferAcceptanceCheck(
+        address operator,
+        address from,
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) private {
+        if (to.isContract()) {
+            try IERC1155Receiver(to).onERC1155Received(operator, from, id, amount, data) returns (bytes4 response) {
+                if (response != IERC1155Receiver(to).onERC1155Received.selector) {
+                    revert("ERC1155: ERC1155Receiver rejected tokens");
+                }
+            } catch Error(string memory reason) {
+                revert(reason);
+            } catch {
+                revert("ERC1155: transfer to non ERC1155Receiver implementer");
+            }
+        }
+    }
+
+    function _doSafeBatchTransferAcceptanceCheck(
+        address operator,
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory amounts,
+        bytes memory data
+    ) private {
+        if (to.isContract()) {
+            try IERC1155Receiver(to).onERC1155BatchReceived(operator, from, ids, amounts, data) returns (
+                bytes4 response
+            ) {
+                if (response != IERC1155Receiver(to).onERC1155BatchReceived.selector) {
+                    revert("ERC1155: ERC1155Receiver rejected tokens");
+                }
+            } catch Error(string memory reason) {
+                revert(reason);
+            } catch {
+                revert("ERC1155: transfer to non ERC1155Receiver implementer");
+            }
+        }
+    }
+
+    function _asSingletonArray(uint256 element) private pure returns (uint256[] memory) {
+        uint256[] memory array = new uint256[](1);
+        array[0] = element;
+
+        return array;
+    }
+}

--- a/contracts/roles/ERC1155Supply.sol
+++ b/contracts/roles/ERC1155Supply.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.6.0;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+
+/**
+ * @dev Extension of ERC1155 that adds tracking of total supply per id.
+ *
+ * Useful for scenarios where Fungible and Non-fungible tokens have to be
+ * clearly identified. Note: While a totalSupply of 1 might mean the
+ * corresponding is an NFT, there is no guarantees that no other token with the
+ * same id are not going to be minted.
+ */
+abstract contract ERC1155Supply is ERC1155 {
+    mapping(uint256 => uint256) private _totalSupply;
+
+    /**
+     * @dev Total amount of tokens in with a given id.
+     */
+    function totalSupply(uint256 id) public view virtual returns (uint256) {
+        return _totalSupply[id];
+    }
+
+    /**
+     * @dev Indicates weither any token exist with a given id, or not.
+     */
+    function exists(uint256 id) public view virtual returns (bool) {
+        return ERC1155Supply.totalSupply(id) > 0;
+    }
+
+    /**
+     * @dev See {ERC1155-_mint}.
+     */
+    function _mint(
+        address account,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) internal virtual override {
+        super._mint(account, id, amount, data);
+        _totalSupply[id] += amount;
+    }
+
+    /**
+     * @dev See {ERC1155-_mintBatch}.
+     */
+    function _mintBatch(
+        address to,
+        uint256[] memory ids,
+        uint256[] memory amounts,
+        bytes memory data
+    ) internal virtual override {
+        super._mintBatch(to, ids, amounts, data);
+        for (uint256 i = 0; i < ids.length; ++i) {
+            _totalSupply[ids[i]] += amounts[i];
+        }
+    }
+
+    /**
+     * @dev See {ERC1155-_burn}.
+     */
+    function _burn(
+        address account,
+        uint256 id,
+        uint256 amount
+    ) internal virtual override {
+        super._burn(account, id, amount);
+        _totalSupply[id] -= amount;
+    }
+
+    /**
+     * @dev See {ERC1155-_burnBatch}.
+     */
+    function _burnBatch(
+        address account,
+        uint256[] memory ids,
+        uint256[] memory amounts
+    ) internal virtual override {
+        super._burnBatch(account, ids, amounts);
+        for (uint256 i = 0; i < ids.length; ++i) {
+            _totalSupply[ids[i]] -= amounts[i];
+        }
+    }
+}

--- a/contracts/roles/ERC1155Supply.sol
+++ b/contracts/roles/ERC1155Supply.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.6.0;
 
-import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import "./ERC1155.sol";
 
 /**
  * @dev Extension of ERC1155 that adds tracking of total supply per id.

--- a/contracts/roles/MurAllRolesNFT.sol
+++ b/contracts/roles/MurAllRolesNFT.sol
@@ -25,6 +25,7 @@ contract MurAllRolesNFT is ERC1155Supply, ReentrancyGuard, AccessControl, Ownabl
     mapping(uint256 => Role) public roles;
 
     event RoleClaimed(uint256 indexed id, address owner);
+    event RoleAdded(uint256 indexed id);
     /** @dev Checks if sender address has admin role
      */
     modifier onlyAdmin() {
@@ -54,6 +55,7 @@ contract MurAllRolesNFT is ERC1155Supply, ReentrancyGuard, AccessControl, Ownabl
         Role memory role = Role(true, _root);
 
         roles[id] = role;
+        emit RoleAdded(id);
     }
 
     function setupClaimMerkleRootForRole(uint256 id, bytes32 _root) public onlyAdmin {

--- a/contracts/roles/MurAllRolesNFT.sol
+++ b/contracts/roles/MurAllRolesNFT.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.6.0;
+
+import "./ERC1155Supply.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "../MurAll.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/cryptography/MerkleProof.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract MurAllRolesNFT is ERC1155Supply, ReentrancyGuard, AccessControl, Ownable {
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
+
+    struct Role {
+        bool exists;
+        bytes32 merkleRoot;
+        mapping(address => bool) claimedRole;
+    }
+    uint256 public constant TYPE_PAINTER = 1;
+    uint256 public constant TYPE_MURALLIST = 2;
+
+    MurAll public murAll;
+
+    mapping(uint256 => Role) public roles;
+
+    event RoleClaimed(uint256 indexed id, address owner);
+    /** @dev Checks if sender address has admin role
+     */
+    modifier onlyAdmin() {
+        require(hasRole(ADMIN_ROLE, msg.sender), "Does not have admin role");
+        _;
+    }
+
+    constructor(
+        address[] memory admins,
+        string memory uri,
+        MurAll _murAllAddr
+    ) public ERC1155(uri) {
+        for (uint256 i = 0; i < admins.length; ++i) {
+            _setupRole(ADMIN_ROLE, admins[i]);
+        }
+        murAll = _murAllAddr;
+        Role memory role = Role(true, "");
+        roles[TYPE_PAINTER] = role;
+
+        Role memory role2 = Role(true, "");
+        roles[TYPE_MURALLIST] = role2;
+    }
+
+    function addRole(uint256 id, bytes32 _root) public onlyAdmin {
+        require(!roles[id].exists, "Role already exists");
+
+        Role memory role = Role(true, _root);
+
+        roles[id] = role;
+    }
+
+    function setupClaimMerkleRootForRole(uint256 id, bytes32 _root) public onlyAdmin {
+        Role storage role = roles[id];
+        require(role.exists, "Role does not exist");
+
+        role.merkleRoot = _root;
+    }
+
+    function mintRole(address _to, uint256 _id) public onlyAdmin {
+        Role storage role = roles[_id];
+        require(role.exists, "Role does not exist");
+        require(role.claimedRole[_to] == false, "Role already claimed");
+
+        role.claimedRole[_to] = true;
+        _mint(_to, _id, 1, "");
+        emit RoleClaimed(_id, _to);
+    }
+
+    function mintMultiple(address[] memory _to, uint256[] memory _ids) public onlyAdmin {
+        for (uint256 i = 0; i < _ids.length; i++) {
+            Role storage role = roles[_ids[i]];
+            require(role.exists, "Role does not exist");
+            require(role.claimedRole[_to[i]] == false, "Role already claimed");
+
+            role.claimedRole[_to[i]] = true;
+            _mint(_to[i], _ids[i], 1, "");
+            emit RoleClaimed(_ids[i], _to[i]);
+        }
+    }
+
+    function claimPainterRoleL1() public nonReentrant {
+        require(murAll.isArtist(msg.sender), "Only painter can claim painter role");
+        Role storage role = roles[TYPE_PAINTER];
+
+        require(role.claimedRole[msg.sender] == false, "Role already claimed");
+
+        role.claimedRole[msg.sender] = true;
+        _mint(msg.sender, TYPE_PAINTER, 1, "");
+        emit RoleClaimed(TYPE_PAINTER, msg.sender);
+    }
+
+    function claimRole(
+        uint256 index,
+        uint256 roleId,
+        bytes32[] calldata merkleProof
+    ) public nonReentrant {
+        Role storage role = roles[roleId];
+        require(role.exists, "Role does not exist");
+        require(role.claimedRole[msg.sender] == false, "Role already claimed");
+
+        // Verify the merkle proof.
+        bytes32 node = keccak256(abi.encodePacked(index, msg.sender, roleId));
+        require(MerkleProof.verify(merkleProof, role.merkleRoot, node), "Invalid proof.");
+
+        role.claimedRole[msg.sender] = true;
+
+        _mint(msg.sender, roleId, 1, "");
+        emit RoleClaimed(roleId, msg.sender);
+    }
+
+    function hasClaimedRole(address _to, uint256 roleId) public view returns (bool) {
+        Role storage role = roles[roleId];
+        return role.exists && role.claimedRole[_to];
+    }
+
+    function roleExists(uint256 roleId) public view returns (bool) {
+        return roles[roleId].exists;
+    }
+
+    function setURI(string memory newuri) public onlyAdmin {
+        _setURI(newuri);
+    }
+}

--- a/migrations/13_deploy_murall_roles.js
+++ b/migrations/13_deploy_murall_roles.js
@@ -2,7 +2,8 @@ var MurAllRolesNFT = artifacts.require('./roles/MurAllRolesNFT.sol')
 
 const MURALL_RINKEBY = '0x0877F939731384FD41eB599EA5Bb3c32b642845f'
 const MURALL_MAINNET = '0x6442bDfd16352726AA25Ad6b3CBAb3865c05ED15'
-const BASE_URI = 'ipfs://QmQcYjqbfEMz4bTTgCnBm6aEY3DuViqH7sqEyLMfpAd5SS/{id}'
+const PAINTER_URI = 'ipfs://QmPZemnaJ7JAvkc1AL3FhBUB7Y3v1aLiEb9yjDqAaKmAqN/1'
+const MURALLIST_URI = 'ipfs://QmPZemnaJ7JAvkc1AL3FhBUB7Y3v1aLiEb9yjDqAaKmAqN/2'
 
 module.exports = async function (deployer, network, accounts) {
     const murAllAddress = network == 'mainnet' ? MURALL_MAINNET : MURALL_RINKEBY
@@ -14,7 +15,8 @@ module.exports = async function (deployer, network, accounts) {
             '0x9388517B36B817DCCbb663a3097f4c5fFDBeCC14',
             '0xF7A3bBe1711Eb43967cdbf58FA61342a25E3c845'
         ],
-        BASE_URI,
+        PAINTER_URI,
+        MURALLIST_URI,
         murAllAddress
     )
 }

--- a/migrations/13_deploy_murall_roles.js
+++ b/migrations/13_deploy_murall_roles.js
@@ -1,0 +1,20 @@
+var MurAllRolesNFT = artifacts.require('./roles/MurAllRolesNFT.sol')
+
+const MURALL_RINKEBY = '0x0877F939731384FD41eB599EA5Bb3c32b642845f'
+const MURALL_MAINNET = '0x6442bDfd16352726AA25Ad6b3CBAb3865c05ED15'
+const BASE_URI = 'ipfs://QmQcYjqbfEMz4bTTgCnBm6aEY3DuViqH7sqEyLMfpAd5SS/{id}'
+
+module.exports = async function (deployer, network, accounts) {
+    const murAllAddress = network == 'mainnet' ? MURALL_MAINNET : MURALL_RINKEBY
+
+    await deployer.deploy(
+        MurAllRolesNFT,
+        [
+            '0xCF90AD693aCe601b5B5582C4F95eC7266CDB3eEC',
+            '0x9388517B36B817DCCbb663a3097f4c5fFDBeCC14',
+            '0xF7A3bBe1711Eb43967cdbf58FA61342a25E3c845'
+        ],
+        BASE_URI,
+        murAllAddress
+    )
+}

--- a/test/MurAllRolesNFT.test.js
+++ b/test/MurAllRolesNFT.test.js
@@ -243,7 +243,7 @@ contract('MurAllRolesNFT', ([owner, user, randomer]) => {
 
         it('with valid proof from address matching proofs but has already been claimed fails', async () => {
             const claimProof = merkleProof.claims[user]
-            
+
             await this.murAllRolesNFT.claimRole(claimProof.index, claimProof.amount, claimProof.proof, {
                 from: user
             })
@@ -279,8 +279,12 @@ contract('MurAllRolesNFT', ([owner, user, randomer]) => {
             })
 
             it('from admin account succeeds', async () => {
-                await this.murAllRolesNFT.addRole(newRoleId, merkleRoot, {
+                const receipt = await this.murAllRolesNFT.addRole(newRoleId, merkleRoot, {
                     from: owner
+                })
+
+                await expectEvent(receipt, 'RoleAdded', {
+                    id: newRoleId.toString()
                 })
 
                 assert.isTrue(await this.murAllRolesNFT.roleExists(newRoleId))

--- a/test/MurAllRolesNFT.test.js
+++ b/test/MurAllRolesNFT.test.js
@@ -1,0 +1,473 @@
+const { time, BN, expectRevert, expectEvent, constants } = require('@openzeppelin/test-helpers')
+const Web3 = require('web3')
+const web3 = new Web3(new Web3.providers.HttpProvider('http://127.0.0.1:7545'))
+const timeMachine = require('ganache-time-traveler')
+const { ZERO_ADDRESS } = require('@openzeppelin/test-helpers/src/constants')
+require('chai').should()
+const { expect } = require('chai')
+
+const MurAll = artifacts.require('./MurAll.sol')
+const MurAllNFT = artifacts.require('./MurAllNFT.sol')
+const PaintToken = artifacts.require('./PaintToken.sol')
+const DataValidator = artifacts.require('./validator/MurAllDataValidator.sol')
+const NftImageDataStorage = artifacts.require('./storage/NftImageDataStorage.sol')
+
+const MurAllRolesNFT = artifacts.require('./roles/MurAllRolesNFT')
+
+contract('MurAllRolesNFT', ([owner, user, randomer]) => {
+    const to18DP = value => {
+        return new BN(value).mul(new BN('10').pow(new BN('18')))
+    }
+
+    const toBn = value => new BN(value)
+    const PRICE_PER_PIXEL = 500000000000000000
+    const setAllowance = async (address, pixelCount) => {
+        const requiredTokens = web3.utils.toBN(PRICE_PER_PIXEL).mul(web3.utils.toBN(pixelCount))
+        await this.paintToken.transfer(address, requiredTokens, { from: owner })
+        await this.paintToken.approve(this.murAllContract.address, requiredTokens, { from: address })
+    }
+
+    const mintOnMurAll = async fromAddress => {
+        // given
+        const colourIndexValue = web3.utils.toBN('0xaabbccddeeff00112233445566778899aabbccddeeff00112233445566778899')
+        const pixel = web3.utils.toBN('0x0012d61F0012d61F0012d61F0012d61F0012d61F0012d61F0012d61F0012d61F')
+        const pixelGroup = web3.utils.toBN('0x26a4d3a4217ad135efa1f04d7e4ef6a2f0a240be135e17a75fa2414eb2fad6ab')
+        const pixelGroupIndex = web3.utils.toBN('0x3039303930393039303930393039303930393039303930393039303930393039')
+        const transparentPixelGroup = web3.utils.toBN(
+            '0x36a4d3a4217ad135efa1f04d7e4ef6a2f0a240be135e17a75fa2414eb2fad6ab'
+        )
+        const transparentPixelGroupIndex = web3.utils.toBN(
+            '0x4039303930393039303930393039303930393039303930393039303930393039'
+        )
+
+        const colourIndexes = [colourIndexValue]
+        const pixelData = [pixel]
+        const pixelGroups = [pixelGroup]
+        const pixelGroupIndexes = [pixelGroupIndex]
+        const transparentPixelGroups = [transparentPixelGroup]
+        const transparentPixelGroupIndexes = [transparentPixelGroupIndex]
+        const metadata = [
+            '0x68656c6c6f20776f726c64210000000000000000000000000000000000000000',
+
+            '0x0004D200162E0000000000000000000000000000000000000000000000000000'
+        ]
+
+        await setAllowance(fromAddress, 72)
+
+        await this.murAllContract.setPixels(
+            colourIndexes,
+            pixelData,
+            pixelGroups,
+            pixelGroupIndexes,
+            transparentPixelGroups,
+            transparentPixelGroupIndexes,
+            metadata,
+
+            {
+                from: fromAddress
+            }
+        )
+    }
+
+    const BASE_URI = 'https://example.com'
+    const TYPE_PAINTER = 1
+    const TYPE_MURALLIST = 2
+
+    const merkleProof = {
+        merkleRoot: '0x0cb9c784398ca4068b481b7b7bd55e5f4d4172af144e6afa2ce198c122df25b0',
+        tokenTotal: '0x7e',
+        claims: {
+            '0x6F1737ec98d201F5562330d8E34E311559d30c5A': {
+                index: 0,
+                amount: '0x7b',
+                proof: [
+                    '0x1d5ee70027162ef9dc744f12a4419a656ebf27d320ca033be999a80a289b0385',
+                    '0xb639487c506b5aa1493aaed75f470ee2232cc671ac684aab32ec463e54418ff9'
+                ]
+            },
+            '0x6d9a80f7FC4270787643f46250344Cc0D90384F6': {
+                index: 1,
+                amount: '0x02',
+                proof: ['0x291f19e5d647b447d0fc26999f55dc6c40c576e12c26e152ff7c9d91b8c3f675']
+            },
+            '0xf533897fd7A5E2bCF72e920b6333dDf75c0B7fdE': {
+                index: 2,
+                amount: '0x01',
+                proof: [
+                    '0x855846339247e0af414e34b538429a9028d0396144deb55fb9a616ccda1e45c6',
+                    '0xb639487c506b5aa1493aaed75f470ee2232cc671ac684aab32ec463e54418ff9'
+                ]
+            }
+        }
+    }
+
+    beforeEach(async () => {
+        this.NftImageDataStorage = await NftImageDataStorage.new({ from: owner })
+        this.murAllNFT = await MurAllNFT.new([owner], this.NftImageDataStorage.address, { from: owner })
+        await this.NftImageDataStorage.transferOwnership(this.murAllNFT.address)
+
+        this.paintToken = await PaintToken.new({ from: owner })
+        this.dataValidator = await DataValidator.new({ from: owner })
+        this.murAllContract = await MurAll.new(
+            this.paintToken.address,
+            this.murAllNFT.address,
+            this.dataValidator.address,
+            [owner],
+            {
+                from: owner
+            }
+        )
+        await this.murAllNFT.transferOwnership(this.murAllContract.address, { from: owner })
+
+        this.murAllRolesNFT = await MurAllRolesNFT.new([owner], BASE_URI, this.murAllContract.address, { from: owner })
+
+        this.startBlock = await time.latestBlock()
+    })
+
+    describe('Deployment', async () => {
+        it('deploys successfully', async () => {
+            const address = this.murAllRolesNFT.address
+
+            assert.notEqual(address, '')
+            assert.notEqual(address, 0x0)
+            assert.notEqual(address, null)
+            assert.notEqual(address, undefined)
+        })
+
+        it('adds painter role by default', async () => {
+            const address = this.murAllRolesNFT.address
+
+            assert.equal(await this.murAllRolesNFT.TYPE_PAINTER(), TYPE_PAINTER)
+            assert.isTrue(await this.murAllRolesNFT.roleExists(TYPE_PAINTER))
+        })
+
+        it('adds MurAllist role by default', async () => {
+            const address = this.murAllRolesNFT.address
+
+            assert.equal(await this.murAllRolesNFT.TYPE_MURALLIST(), TYPE_MURALLIST)
+            assert.isTrue(await this.murAllRolesNFT.roleExists(TYPE_MURALLIST))
+        })
+    })
+    describe('claimPainterRoleL1', async () => {
+        beforeEach(async () => {
+            await mintOnMurAll(user)
+        })
+
+        it('from account that has not painted on MurAll fails', async () => {
+            await expectRevert(
+                this.murAllRolesNFT.claimPainterRoleL1({
+                    from: randomer
+                }),
+                'Only painter can claim painter role'
+            )
+        })
+
+        it('from account who has painted on MurAll succeeds', async () => {
+            const receipt = await this.murAllRolesNFT.claimPainterRoleL1({
+                from: user
+            })
+
+            await expectEvent(receipt, 'RoleClaimed', {
+                id: TYPE_PAINTER.toString(),
+                owner: user
+            })
+
+            assert.isTrue(await this.murAllRolesNFT.hasClaimedRole(user, TYPE_PAINTER))
+            assert.equal(await this.murAllRolesNFT.balanceOf(user, TYPE_PAINTER), 1)
+        })
+
+        it('cannot claim once already claimed', async () => {
+            await this.murAllRolesNFT.claimPainterRoleL1({
+                from: user
+            })
+
+            await expectRevert(
+                this.murAllRolesNFT.claimPainterRoleL1({
+                    from: user
+                }),
+                'Role already claimed'
+            )
+        })
+    })
+
+    describe('claimRole', async () => {
+        beforeEach(async () => {
+            await this.murAllRolesNFT.setupClaimMerkleRootForRole(TYPE_PAINTER, merkleProof.merkleRoot, {
+                from: owner
+            })
+        })
+
+        it('with role id that does not exist fails', async () => {
+            const claimProof = merkleProof.claims[user]
+            await expectRevert(
+                this.murAllRolesNFT.claimRole(claimProof.index, 123, claimProof.proof, {
+                    from: user
+                }),
+                'Role does not exist.'
+            )
+        })
+
+        it('with invalid proof fails', async () => {
+            const claimProof = merkleProof.claims[user]
+            await expectRevert(
+                this.murAllRolesNFT.claimRole(claimProof.index, claimProof.amount, merkleProof.claims[randomer].proof, {
+                    from: user
+                }),
+                'Invalid proof.'
+            )
+        })
+
+        it('with valid proof from address not matching proofs fails', async () => {
+            const claimProof = merkleProof.claims[user]
+            await expectRevert(
+                this.murAllRolesNFT.claimRole(claimProof.index, claimProof.amount, claimProof.proof, {
+                    from: randomer
+                }),
+                'Invalid proof.'
+            )
+        })
+
+        it('with valid proof from address matching proofs succeeds', async () => {
+            const claimProof = merkleProof.claims[user]
+            const receipt = await this.murAllRolesNFT.claimRole(claimProof.index, claimProof.amount, claimProof.proof, {
+                from: user
+            })
+
+            await expectEvent(receipt, 'RoleClaimed', {
+                id: TYPE_PAINTER.toString(),
+                owner: user
+            })
+
+            assert.isTrue(await this.murAllRolesNFT.hasClaimedRole(user, claimProof.amount))
+        })
+
+        it('with valid proof from address matching proofs but has already been claimed fails', async () => {
+            const claimProof = merkleProof.claims[user]
+            
+            await this.murAllRolesNFT.claimRole(claimProof.index, claimProof.amount, claimProof.proof, {
+                from: user
+            })
+            await expectRevert(
+                this.murAllRolesNFT.claimRole(claimProof.index, claimProof.amount, claimProof.proof, {
+                    from: user
+                }),
+                'Role already claimed'
+            )
+        })
+    })
+
+    describe('Admin functions', async () => {
+        let newRoleId = 123
+        let merkleRoot = '0x53a727f718138b0a08d032346812ae97b7c5dbf4d1a4f1da857c4d7dadff776c'
+        describe('addRole', async () => {
+            it('from account that is not admin fail', async () => {
+                await expectRevert(
+                    this.murAllRolesNFT.addRole(newRoleId, merkleRoot, {
+                        from: user
+                    }),
+                    'Does not have admin role'
+                )
+            })
+
+            it('with role id that already exists fail', async () => {
+                await expectRevert(
+                    this.murAllRolesNFT.addRole(TYPE_MURALLIST, merkleRoot, {
+                        from: owner
+                    }),
+                    'Role already exists'
+                )
+            })
+
+            it('from admin account succeeds', async () => {
+                await this.murAllRolesNFT.addRole(newRoleId, merkleRoot, {
+                    from: owner
+                })
+
+                assert.isTrue(await this.murAllRolesNFT.roleExists(newRoleId))
+            })
+        })
+
+        describe('setupClaimMerkleRootForRole', async () => {
+            beforeEach(async () => {
+                await this.murAllRolesNFT.addRole(
+                    newRoleId,
+                    '0x53a727f718138b0a08d032346812ae97b7c5dbf4d1a4f1da857c4d7dadff776d',
+                    {
+                        from: owner
+                    }
+                )
+            })
+
+            it('with account that is not admin fails', async () => {
+                await expectRevert(
+                    this.murAllRolesNFT.setupClaimMerkleRootForRole(newRoleId, merkleRoot, {
+                        from: user
+                    }),
+                    'Does not have admin role'
+                )
+            })
+
+            it('for role that doesnt exist fails', async () => {
+                await expectRevert(
+                    this.murAllRolesNFT.setupClaimMerkleRootForRole(newRoleId + 1, merkleRoot, {
+                        from: owner
+                    }),
+                    'Role does not exist'
+                )
+            })
+
+            it('succeeds for admin address with role that exists', async () => {
+                await this.murAllRolesNFT.setupClaimMerkleRootForRole(newRoleId, merkleRoot, {
+                    from: owner
+                })
+                const role = await this.murAllRolesNFT.roles(newRoleId)
+                assert.equal(await role.merkleRoot, merkleRoot)
+            })
+        })
+
+        describe('mintRole', async () => {
+            beforeEach(async () => {
+                await this.murAllRolesNFT.addRole(newRoleId, merkleRoot, {
+                    from: owner
+                })
+            })
+
+            it('with account that is not admin fails', async () => {
+                await expectRevert(
+                    this.murAllRolesNFT.mintRole(user, newRoleId, {
+                        from: user
+                    }),
+                    'Does not have admin role'
+                )
+            })
+
+            it('with role id that does not exist fails', async () => {
+                await expectRevert(
+                    this.murAllRolesNFT.mintRole(user, newRoleId + 1, {
+                        from: owner
+                    }),
+                    'Role does not exist'
+                )
+            })
+
+            it('with existing role id from admin account succeeds', async () => {
+                const receipt = await this.murAllRolesNFT.mintRole(user, newRoleId, {
+                    from: owner
+                })
+
+                await expectEvent(receipt, 'RoleClaimed', {
+                    id: newRoleId.toString(),
+                    owner: user
+                })
+
+                assert.isTrue(await this.murAllRolesNFT.hasClaimedRole(user, newRoleId))
+                assert.equal(await this.murAllRolesNFT.balanceOf(user, newRoleId), 1)
+            })
+
+            it('does not allow minting role id if already claimed', async () => {
+                await this.murAllRolesNFT.mintRole(user, newRoleId, {
+                    from: owner
+                })
+
+                await expectRevert(
+                    this.murAllRolesNFT.mintRole(user, newRoleId, {
+                        from: owner
+                    }),
+                    'Role already claimed'
+                )
+
+                assert.isTrue(await this.murAllRolesNFT.hasClaimedRole(user, newRoleId))
+                assert.equal(await this.murAllRolesNFT.balanceOf(user, newRoleId), 1)
+            })
+        })
+
+        describe('mintMultiple', async () => {
+            beforeEach(async () => {
+                await this.murAllRolesNFT.addRole(newRoleId, merkleRoot, {
+                    from: owner
+                })
+            })
+
+            it('with account that is not admin fails', async () => {
+                await expectRevert(
+                    this.murAllRolesNFT.mintMultiple([user], [newRoleId], {
+                        from: user
+                    }),
+                    'Does not have admin role'
+                )
+            })
+
+            it('with role id that does not exist fails', async () => {
+                await expectRevert(
+                    this.murAllRolesNFT.mintMultiple([user], [newRoleId + 1], {
+                        from: owner
+                    }),
+                    'Role does not exist'
+                )
+            })
+
+            it('with existing role id from admin account succeeds', async () => {
+                const receipt = await this.murAllRolesNFT.mintMultiple([user, randomer], [newRoleId, TYPE_PAINTER], {
+                    from: owner
+                })
+
+                await expectEvent(receipt, 'RoleClaimed', {
+                    id: newRoleId.toString(),
+                    owner: user
+                })
+                await expectEvent(receipt, 'RoleClaimed', {
+                    id: TYPE_PAINTER.toString(),
+                    owner: randomer
+                })
+
+                assert.isTrue(await this.murAllRolesNFT.hasClaimedRole(user, newRoleId))
+                assert.isTrue(await this.murAllRolesNFT.hasClaimedRole(randomer, TYPE_PAINTER))
+                assert.equal(await this.murAllRolesNFT.balanceOf(user, newRoleId), 1)
+                assert.equal(await this.murAllRolesNFT.balanceOf(randomer, TYPE_PAINTER), 1)
+            })
+
+            it('does not allow minting role id if already claimed', async () => {
+                await this.murAllRolesNFT.mintMultiple([user], [newRoleId], {
+                    from: owner
+                })
+
+                await expectRevert(
+                    this.murAllRolesNFT.mintMultiple([user], [newRoleId], {
+                        from: owner
+                    }),
+                    'Role already claimed'
+                )
+
+                assert.isTrue(await this.murAllRolesNFT.hasClaimedRole(user, newRoleId))
+                assert.equal(await this.murAllRolesNFT.balanceOf(user, newRoleId), 1)
+            })
+        })
+        describe('setURI', async () => {
+            beforeEach(async () => {
+                await this.murAllRolesNFT.addRole(newRoleId, merkleRoot, {
+                    from: owner
+                })
+                await this.murAllRolesNFT.mintRole(user, newRoleId, {
+                    from: owner
+                })
+            })
+
+            it('with account that is not admin fails', async () => {
+                await expectRevert(
+                    this.murAllRolesNFT.setURI(BASE_URI, {
+                        from: user
+                    }),
+                    'Does not have admin role'
+                )
+            })
+
+            it('with admin account succeeds', async () => {
+                await this.murAllRolesNFT.setURI(BASE_URI, {
+                    from: owner
+                })
+
+                assert.equal(await this.murAllRolesNFT.uri(newRoleId), BASE_URI)
+            })
+        })
+    })
+})


### PR DESCRIPTION
Note: `Ownable` has only been used to allow the OpenSea collection to be edited upon deployment

- Has Painter/MurAllist roles by default but more can be added
- using merkle claim method to allow users to mint NFTs themselves allowing us to update the merkle root as needed (including the painter and MurAllist roles, which allow us to set a merkle root for addresses of both L2 and L1 to claim the roles)
- rolled in support for L1 MurAll contract for automatic detection of whether someone has painted on MurAll to allow them to mint without the need for proofs